### PR TITLE
Reverse proxy behind apache

### DIFF
--- a/data/apache-freedombuddy.conf
+++ b/data/apache-freedombuddy.conf
@@ -1,0 +1,19 @@
+# Required modules: proxy, proxy_http, rewrite
+
+<Location /freedombuddy>
+    ProxyPass http://localhost:8080
+    ProxyPassReverse http://localhost:8080
+
+    RewriteEngine on
+    RewriteCond %{SERVER_PORT} !^443$
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</Location>
+
+<Location /freedombuddy_monitor>
+    ProxyPass http://localhost:8081
+    ProxyPassReverse http://localhost:8081
+
+    RewriteEngine on
+    RewriteCond %{SERVER_PORT} !^443$
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</Location>

--- a/data/template.cfg
+++ b/data/template.cfg
@@ -13,8 +13,7 @@ connectors = https-listener, https-sender, https-monitor
 
 [https-listener]
 socket_port = 8080
-ssl_certificate = data/freedombuddy.crt
-ssl_private_key = data/freedombuddy.crt
+server_dir = /freedombuddy
 
 [https-sender]
 # See the "Proxy Compatibility" section.  It enumerates the types:
@@ -25,8 +24,7 @@ ssl_private_key = data/freedombuddy.crt
 
 [https-monitor]
 socket_port = 8081
-ssl_certificate = data/freedombuddy.crt
-ssl_private_key = data/freedombuddy.crt
+server_dir = /freedombuddy_monitor
 
 [cli]
 connectors = cli-monitor, cli-sender, cli-listener

--- a/makefile
+++ b/makefile
@@ -2,26 +2,13 @@
 
 DATA_DIR = data
 SCRIPTS_DIR = src/scripts
-CERTIFICATE = $(DATA_DIR)/freedombuddy.crt
 CFG_TEMPLATE = $(DATA_DIR)/template.cfg
 CFG_PRODUCTION = $(DATA_DIR)/production.cfg
+APACHE_CONF=$(DATA_DIR)/apache-freedombuddy.conf
 CFG_TEST = $(DATA_DIR)/test.cfg
 KEYS_TEST = src/tests/data/test_gpg_home/
 
-all: ssl-certificate $(CFG_PRODUCTION) $(CFG_TEST)
-
-ssl-certificate: $(CERTIFICATE)
-
-$(CERTIFICATE):
-ifeq ($(wildcard $(CERTIFICATE)),)
-	sudo make-ssl-cert generate-default-snakeoil
-	sudo make-ssl-cert /usr/share/ssl-cert/ssleay.cnf $(CERTIFICATE)
-	sudo chgrp `id -g | awk '{ print $1 }'` $(CERTIFICATE)
-	sudo chmod g+r $(CERTIFICATE)
-	sudo touch $(CERTIFICATE)
-else
-	echo $(CERTIFICATE) already exists
-endif
+all: $(CFG_PRODUCTION) $(CFG_TEST)
 
 $(CFG_PRODUCTION):
 	cp $(CFG_TEMPLATE) $(CFG_PRODUCTION)
@@ -31,5 +18,9 @@ $(CFG_TEST):
 	cp $(CFG_TEMPLATE) $(CFG_TEST)
 	python src/config/update_encryption_key.py $(CFG_TEST) ~/.gnupg/
 
+install:
+	cp $(APACHE_CONF) /etc/apache2/conf-available/
+	a2enconf apache-freedombuddy
+
 clean:
-	rm -f $(CERTIFICATE) $(CFG_PRODUCTION) $(CFG_TEST)
+	rm -f $(CFG_PRODUCTION) $(CFG_TEST)

--- a/src/connectors/https/templates/html/en/consumedHost.tmpl
+++ b/src/connectors/https/templates/html/en/consumedHost.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 <html>
   <head>
@@ -9,16 +10,16 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> services from
+    <p>You are <a href="$server_dir/consuming">consuming</a> services from
       $host:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape($service)
       <li>
-        <a href="/consuming/$host/$service">
+        <a href="$server_dir/consuming/$host/$service">
           $service</a>
-        <form method="post" action="/consuming/$host">
+        <form method="post" action="$server_dir/consuming/$host">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -27,7 +28,7 @@
     </ul>
     #end if
     <hr />
-    <form method="post" action="/consuming/$host">
+    <form method="post" action="$server_dir/consuming/$host">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/en/consumedService.tmpl
+++ b/src/connectors/https/templates/html/en/consumedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,9 +11,9 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> $service from
-      <a href="/consuming/$host">$host</a> at:</p>
-    <form method="post" action="/query/$host/$service">
+    <p>You are <a href="$server_dir/consuming">consuming</a> $service from
+      <a href="$server_dir/consuming/$host">$host</a> at:</p>
+    <form method="post" action="$server_dir/query/$host/$service">
       <input type="submit" value="Learn More Locations?" />
     </form>
     #if $locations
@@ -22,7 +23,7 @@
       <li>
         <a href="$location">$location</a>
         <form method="post"
-              action="/consuming/$host/$service">
+              action="$server_dir/consuming/$host/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -32,7 +33,7 @@
     #end if
     <hr />
     <form method="post"
-          action="/consuming/$host/$service">
+          action="$server_dir/consuming/$host/$service">
       <label>Location: <input name="put" /></label>
       <input type="submit" value="Create New Location" />
     </form>

--- a/src/connectors/https/templates/html/en/consuming.tmpl
+++ b/src/connectors/https/templates/html/en/consuming.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $host in $hosts
       #set $host = $cgi.escape($host)
-      <li><a href="/consuming/$host">$host</a>
-        <form method="post" action="/consuming">
+      <li><a href="$server_dir/consuming/$host">$host</a>
+        <form method="post" action="$server_dir/consuming">
           <input type="hidden" name="delete" value="$host" />
           <input type="submit" value="Delete" />
         </form>
@@ -24,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/consuming">
+    <form method="post" action="$server_dir/consuming">
       <label>Host: <input name="put" /></label>
       <input type="submit" value="Create New Host" />
     </form>

--- a/src/connectors/https/templates/html/en/hostedClient.tmpl
+++ b/src/connectors/https/templates/html/en/hostedClient.tmpl
@@ -9,13 +9,13 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a> these services for $client:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a> these services for $client:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape(service)
-      <li><a href="/hosting/$client/$service">$service</a>
-        <form method="post" action="/hosting/$client">
+      <li><a href="$server_dir/hosting/$client/$service">$service</a>
+        <form method="post" action="$server_dir/hosting/$client">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -25,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/hosting/$client">
+    <form method="post" action="$server_dir/hosting/$client">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/en/hostedService.tmpl
+++ b/src/connectors/https/templates/html/en/hostedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $client = $cgi.escape($client)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,14 +11,14 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a>
-      $service for <a href="/hosting/$client/">$client</a> at:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a>
+      $service for <a href="$server_dir/hosting/$client/">$client</a> at:</p>
     #if $locations
     <ul>
       #for $location in $locations
       #set $location = $cgi.escape($location)
       <li><a href="$location">$location</a>
-        <form method="post" action="/hosting/$client/$service">
+        <form method="post" action="$server_dir/hosting/$client/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -26,7 +27,7 @@
     </ul>
     #end if
   <hr />
-  <form method="post" action="/hosting/$client/$service">
+  <form method="post" action="$server_dir/hosting/$client/$service">
     <label>Location: 
       <br />
       <textarea name="put" cols="60" rows="20"></textarea>

--- a/src/connectors/https/templates/html/en/hosting.tmpl
+++ b/src/connectors/https/templates/html/en/hosting.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $client in $clients
       #set $client = $cgi.escape($client)
-      <li><a href="/hosting/$client">$client</a>
-        <form method="post" action="/hosting">
+      <li><a href="$server_dir/hosting/$client">$client</a>
+        <form method="post" action="$server_dir/hosting">
           <input type="hidden" name="delete" value="$client" />
           <input type="submit" value="Delete" />
         </form>
@@ -24,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/hosting">
+    <form method="post" action="$server_dir/hosting">
       <label>Client: <input name="put" /></label>
       <input type="submit" value="Create New Client" />
     </form>

--- a/src/connectors/https/templates/html/en/root.tmpl
+++ b/src/connectors/https/templates/html/en/root.tmpl
@@ -1,3 +1,5 @@
+#import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -10,9 +12,9 @@
     <h1>Welcome to FreedomBuddy!</h1>
     <p>You can:</p>
     <ul>
-      <li><a href="/hosting">Host</a> services for others.</li>
-      <li><a href="/consuming">Consume</a> others' services.</li>
-      <li><form method="post" action="/stop">
+      <li><a href="$server_dir/hosting">Host</a> services for others.</li>
+      <li><a href="$server_dir/consuming">Consume</a> others' services.</li>
+      <li><form method="post" action="$server_dir/stop">
           <input type="submit" value="Stop" /></form>
         the FreedomBuddy service.</li>
     </ul>

--- a/src/connectors/https/templates/html/es/consumedHost.tmpl
+++ b/src/connectors/https/templates/html/es/consumedHost.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 <html>
   <head>
@@ -9,16 +10,16 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> services from
+    <p>You are <a href="$server_dir/consuming">consuming</a> services from
       $host:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape($service)
       <li>
-        <a href="/consuming/$host/$service">
+        <a href="$server_dir/consuming/$host/$service">
           $service</a>
-        <form method="post" action="/consuming/$host">
+        <form method="post" action="$server_dir/consuming/$host">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -27,7 +28,7 @@
     </ul>
     #end if
     <hr />
-    <form method="post" action="/consuming/$host">
+    <form method="post" action="$server_dir/consuming/$host">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/es/consumedService.tmpl
+++ b/src/connectors/https/templates/html/es/consumedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,9 +11,9 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> $service from
-      <a href="/consuming/$host">$host</a> at:</p>
-    <form method="post" action="/query/$host/$service">
+    <p>You are <a href="$server_dir/consuming">consuming</a> $service from
+      <a href="$server_dir/consuming/$host">$host</a> at:</p>
+    <form method="post" action="$server_dir/query/$host/$service">
       <input type="submit" value="Learn More Locations?" />
     </form>
     #if $locations
@@ -22,7 +23,7 @@
       <li>
         <a href="$location">$location</a>
         <form method="post"
-              action="/consuming/$host/$service">
+              action="$server_dir/consuming/$host/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -32,7 +33,7 @@
     #end if
     <hr />
     <form method="post"
-          action="/consuming/$host/$service">
+          action="$server_dir/consuming/$host/$service">
       <label>Location: <input name="put" /></label>
       <input type="submit" value="Create New Location" />
     </form>

--- a/src/connectors/https/templates/html/es/consuming.tmpl
+++ b/src/connectors/https/templates/html/es/consuming.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $host in $hosts
       #set $host = $cgi.escape($host)
-      <li><a href="/consuming/$host">$host</a>
-        <form method="post" action="/consuming">
+      <li><a href="$server_dir/consuming/$host">$host</a>
+        <form method="post" action="$server_dir/consuming">
           <input type="hidden" name="delete" value="$host" />
           <input type="submit" value="Delete" />
         </form>
@@ -24,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/consuming">
+    <form method="post" action="$server_dir/consuming">
       <label>Host: <input name="put" /></label>
       <input type="submit" value="Create New Host" />
     </form>

--- a/src/connectors/https/templates/html/es/hostedClient.tmpl
+++ b/src/connectors/https/templates/html/es/hostedClient.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $client = $cgi.escape($client)
 <html>
   <head>
@@ -9,13 +10,13 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a> these services for $client:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a> these services for $client:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape(service)
-      <li><a href="/hosting/$client/$service">$service</a>
-        <form method="post" action="/hosting/$client">
+      <li><a href="$server_dir/hosting/$client/$service">$service</a>
+        <form method="post" action="$server_dir/hosting/$client">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -25,7 +26,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/hosting/$client">
+    <form method="post" action="$server_dir/hosting/$client">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/es/hostedService.tmpl
+++ b/src/connectors/https/templates/html/es/hostedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $client = $cgi.escape($client)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,14 +11,14 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a>
-      $service for <a href="/hosting/$client/">$client</a> at:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a>
+      $service for <a href="$server_dir/hosting/$client/">$client</a> at:</p>
     #if $locations
     <ul>
       #for $location in $locations
       #set $location = $cgi.escape($location)
       <li><a href="$location">$location</a>
-        <form method="post" action="/hosting/$client/$service">
+        <form method="post" action="$server_dir/hosting/$client/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -26,7 +27,7 @@
     </ul>
     #end if
   <hr />
-  <form method="post" action="/hosting/$client/$service">
+  <form method="post" action="$server_dir/hosting/$client/$service">
     <label>Location: <input name="put" /></label>
     <input type="submit" value="Create New Location" />
   </form>

--- a/src/connectors/https/templates/html/es/hosting.tmpl
+++ b/src/connectors/https/templates/html/es/hosting.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $client in $clients
       #set $client = $cgi.escape($client)
-      <li><a href="/hosting/$client">$client</a>
-        <form method="post" action="/hosting">
+      <li><a href="$server_dir/hosting/$client">$client</a>
+        <form method="post" action="$server_dir/hosting">
           <input type="hidden" name="delete" value="$client" />
           <input type="submit" value="Delete" />
         </form>
@@ -24,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/hosting">
+    <form method="post" action="$server_dir/hosting">
       <label>Client: <input name="put" /></label>
       <input type="submit" value="Create New Client" />
     </form>

--- a/src/connectors/https/templates/html/es/root.tmpl
+++ b/src/connectors/https/templates/html/es/root.tmpl
@@ -1,3 +1,5 @@
+#import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -10,9 +12,9 @@
     <h1>Welcome to FreedomBuddy!</h1>
     <p>You can:</p>
     <ul>
-      <li><a href="/hosting">Host</a> services for others.</li>
-      <li><a href="/consuming">Consume</a> others' services.</li>
-      <li><form method="post" action="/stop">
+      <li><a href="$server_dir/hosting">Host</a> services for others.</li>
+      <li><a href="$server_dir/consuming">Consume</a> others' services.</li>
+      <li><form method="post" action="$server_dir/stop">
           <input type="submit" value="Stop" /></form>
         the FreedomBuddy service.</li>
     </ul>

--- a/src/connectors/https/templates/html/fa/consumedHost.tmpl
+++ b/src/connectors/https/templates/html/fa/consumedHost.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 <html>
   <head>
@@ -9,16 +10,16 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> services from
+    <p>You are <a href="$server_dir/consuming">consuming</a> services from
       $host:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape($service)
       <li>
-        <a href="/consuming/$host/$service">
+        <a href="$server_dir/consuming/$host/$service">
           $service</a>
-        <form method="post" action="/consuming/$host">
+        <form method="post" action="$server_dir/consuming/$host">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -27,7 +28,7 @@
     </ul>
     #end if
     <hr />
-    <form method="post" action="/consuming/$host">
+    <form method="post" action="$server_dir/consuming/$host">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/fa/consumedService.tmpl
+++ b/src/connectors/https/templates/html/fa/consumedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $host = $cgi.escape($host)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,9 +11,9 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/consuming">consuming</a> $service from
-      <a href="/consuming/$host">$host</a> at:</p>
-    <form method="post" action="/query/$host/$service">
+    <p>You are <a href="$server_dir/consuming">consuming</a> $service from
+      <a href="$server_dir/consuming/$host">$host</a> at:</p>
+    <form method="post" action="$server_dir/query/$host/$service">
       <input type="submit" value="Learn More Locations?" />
     </form>
     #if $locations
@@ -22,7 +23,7 @@
       <li>
         <a href="$location">$location</a>
         <form method="post"
-              action="/consuming/$host/$service">
+              action="$server_dir/consuming/$host/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -32,7 +33,7 @@
     #end if
     <hr />
     <form method="post"
-          action="/consuming/$host/$service">
+          action="$server_dir/consuming/$host/$service">
       <label>Location: <input name="put" /></label>
       <input type="submit" value="Create New Location" />
     </form>

--- a/src/connectors/https/templates/html/fa/consuming.tmpl
+++ b/src/connectors/https/templates/html/fa/consuming.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $host in $hosts
       #set $host = $cgi.escape($host)
-      <li><a href="/consuming/$host">$host</a>
-        <form method="post" action="/consuming">
+      <li><a href="$server_dir/consuming/$host">$host</a>
+        <form method="post" action="$server_dir/consuming">
           <input type="hidden" name="delete" value="$host" />
           <input type="submit" value="Delete" />
         </form>
@@ -24,7 +25,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/consuming">
+    <form method="post" action="$server_dir/consuming">
       <label>Host: <input name="put" /></label>
       <input type="submit" value="Create New Host" />
     </form>

--- a/src/connectors/https/templates/html/fa/hostedClient.tmpl
+++ b/src/connectors/https/templates/html/fa/hostedClient.tmpl
@@ -1,4 +1,5 @@
-#import cgi
+#import cg
+#set $server_dir = $cgi.escape($server_dir)
 #set $client = $cgi.escape($client)
 <html>
   <head>
@@ -9,13 +10,13 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a> these services for $client:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a> these services for $client:</p>
     #if $services
     <ul>
       #for $service in $services
       #set $service = $cgi.escape(service)
-      <li><a href="/hosting/$client/$service">$service</a>
-        <form method="post" action="/hosting/$client">
+      <li><a href="$server_dir/hosting/$client/$service">$service</a>
+        <form method="post" action="$server_dir/hosting/$client">
           <input type="hidden" name="delete" value="$service" />
           <input type="submit" value="Delete" />
         </form>
@@ -25,7 +26,7 @@
     #end if
 
     <hr />
-    <form method="post" action="/hosting/$client">
+    <form method="post" action="$server_dir/hosting/$client">
       <label>Service: <input name="put" /></label>
       <input type="submit" value="Create New Service" />
     </form>

--- a/src/connectors/https/templates/html/fa/hostedService.tmpl
+++ b/src/connectors/https/templates/html/fa/hostedService.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 #set $client = $cgi.escape($client)
 #set $service = $cgi.escape($service)
 <html>
@@ -10,14 +11,14 @@
     </style>
   </head>
   <body>
-    <p>You are <a href="/hosting">hosting</a>
-      $service for <a href="/hosting/$client/">$client</a> at:</p>
+    <p>You are <a href="$server_dir/hosting">hosting</a>
+      $service for <a href="$server_dir/hosting/$client/">$client</a> at:</p>
     #if $locations
     <ul>
       #for $location in $locations
       #set $location = $cgi.escape($location)
       <li><a href="$location">$location</a>
-        <form method="post" action="/hosting/$client/$service">
+        <form method="post" action="$server_dir/hosting/$client/$service">
           <input type="hidden" name="delete" value="$location" />
           <input type="submit" value="Delete" />
         </form>
@@ -26,7 +27,7 @@
     </ul>
     #end if
   <hr />
-  <form method="post" action="/hosting/$client/$service">
+  <form method="post" action="$server_dir/hosting/$client/$service">
     <label>Location: <input name="put" /></label>
     <input type="submit" value="Create New Location" />
   </form>

--- a/src/connectors/https/templates/html/fa/hosting.tmpl
+++ b/src/connectors/https/templates/html/fa/hosting.tmpl
@@ -1,4 +1,5 @@
 #import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -13,8 +14,8 @@
     <ul>
       #for $client in $clients
       #set $client = $cgi.escape($client)
-      <li><a href="/hosting/$client">$client</a>
-        <form method="post" action="/hosting">
+      <li><a href="$server_dir/hosting/$client">$client</a>
+        <form method="post" action="$server_dir/hosting">
           <input type="hidden" name="delete" value="$client" />
           <input type="submit" value="Delete" />
         </form>
@@ -25,7 +26,7 @@
 
     <hr />
     <form method="post" action="/hosting">
-      <label>Client: <input name="put" /></label>
+      <label>Client: <input name$server_dir="put" /></label>
       <input type="submit" value="Create New Client" />
     </form>
   </body>

--- a/src/connectors/https/templates/html/fa/root.tmpl
+++ b/src/connectors/https/templates/html/fa/root.tmpl
@@ -1,3 +1,5 @@
+#import cgi
+#set $server_dir = $cgi.escape($server_dir)
 <html>
   <head>
     <style>
@@ -10,9 +12,9 @@
     <h1>Welcome to FreedomBuddy!</h1>
     <p>You can:</p>
     <ul>
-      <li><a href="/hosting">Host</a> services for others.</li>
-      <li><a href="/consuming">Consume</a> others' services.</li>
-      <li><form method="post" action="/stop">
+      <li><a href="$server_dir/hosting">Host</a> services for others.</li>
+      <li><a href="$server_dir/consuming">Consume</a> others' services.</li>
+      <li><form method="post" action="$server_dir/stop">
           <input type="submit" value="Stop" /></form>
         the FreedomBuddy service.</li>
     </ul>

--- a/src/tests/test_santiago_run.py
+++ b/src/tests/test_santiago_run.py
@@ -95,7 +95,9 @@ class RoundTrip(EndToEnd):
         import pprint
         for command in commands:
             process = subprocess.Popen(
-                shlex.split(command.format(self.mykey)))
+                shlex.split(command.format(self.mykey)),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
 
             # communicate blocks while each command completes
             (output, error) = process.communicate()


### PR DESCRIPTION
- FreedomBuddy is served at /freedombuddy.
- Monitor is served at /freedombuddy_monitor.
- Redirect http:// to https://.
- Don't generate our own SSL certificate.
- Add server_dir to configuration for listener and monitor.
- Disabled certificate verification for outgoing_request. Maybe there's a better way to handle this.
- Fixed round trip test. The unit tests all pass for me, but I haven't gotten Travis CI to run correctly yet.